### PR TITLE
Fix mouse look code

### DIFF
--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -272,12 +272,14 @@ void Renderer::joystick(int joy, int event){
 	_camera.joystick(joy, event);
 }
 
-void Renderer::buttonPressed(int button, int action, double x, double y){
+void Renderer::buttonPressed(GLFWwindow* window, int button, int action, double x, double y){
 	if (button == GLFW_MOUSE_BUTTON_LEFT) {
 		if (action == GLFW_PRESS) {
 			_camera.mouse(MouseMode::Start,(float)x, (float)y);
+			glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_DISABLED);
 		} else if (action == GLFW_RELEASE) {
 			_camera.mouse(MouseMode::End, 0.0, 0.0);
+			glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_NORMAL);
 		}
 	} else {
 		std::cout << "Button: " << button << ", action: " << action << std::endl;

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -42,7 +42,7 @@ public:
 	void joystick(int joy, int event);
 
 	/// Handle mouse inputs
-	void buttonPressed(int button, int action, double x, double y);
+	void buttonPressed(GLFWwindow* window, int button, int action, double x, double y);
 
 	void mousePosition(double x, double y, bool leftPress, bool rightPress);
 	

--- a/src/camera/Camera.cpp
+++ b/src/camera/Camera.cpp
@@ -87,9 +87,9 @@ void Camera::mouse(MouseMode mode, float x, float y){
 	if (mode == MouseMode::End) {
 		_keyboard.endLeftMouse();
 	} else {
-		// We normalize the x and y values to the [-1, 1] range.
-		float xPosition =  fmax(fmin(1.0f, 2.0f * x / _screenSize[0] - 1.0f),-1.0f);
-		float yPosition =  fmax(fmin(1.0f, 2.0f * y / _screenSize[1] - 1.0f),-1.0f);
+		// We normalize the x and y values to the screen size.
+		float xPosition =  2.0f * x / _screenSize[0] - 1.0f;
+		float yPosition =  2.0f * y / _screenSize[1] - 1.0f;
 		
 		if(mode == MouseMode::Start) {
 			_keyboard.startLeftMouse(xPosition,yPosition);

--- a/src/camera/Camera.cpp
+++ b/src/camera/Camera.cpp
@@ -87,14 +87,10 @@ void Camera::mouse(MouseMode mode, float x, float y){
 	if (mode == MouseMode::End) {
 		_keyboard.endLeftMouse();
 	} else {
-		// We normalize the x and y values to the screen size.
-		float xPosition =  2.0f * x / _screenSize[0] - 1.0f;
-		float yPosition =  2.0f * y / _screenSize[1] - 1.0f;
-		
 		if(mode == MouseMode::Start) {
-			_keyboard.startLeftMouse(xPosition,yPosition);
+			_keyboard.startLeftMouse(x,y);
 		} else {
-			_keyboard.leftMouseTo(xPosition,yPosition);
+			_keyboard.leftMouseTo(x,y);
 		}
 	}
 }

--- a/src/camera/Keyboard.h
+++ b/src/camera/Keyboard.h
@@ -36,8 +36,8 @@ private:
 	float _speed;
 	float _angularSpeed;
 	
-	glm::vec2 _previousPosition;
-	glm::vec2 _deltaPosition;
+	glm::vec2 _mousePos;
+	glm::vec2 _look;
 
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,7 +34,7 @@ void mouse_button_callback(GLFWwindow* window, int button, int action, int mods)
 	double x, y;
     glfwGetCursorPos(window, &x, &y);
 	Renderer *rendererPtr = static_cast<Renderer*>(glfwGetWindowUserPointer(window));
-	rendererPtr->buttonPressed(button, action, x, y);
+	rendererPtr->buttonPressed(window, button, action, x, y);
 }
 
 


### PR DESCRIPTION
This PR rewrites the mouse look code and fixes several issues with the mouse look behavior. Camera pitch is now clamped to [-90, 90] degrees. Camera will no longer roll. Moving the camera sideways will no longer rotate the camera.